### PR TITLE
Add Plex parsing rules for TV Shows.

### DIFF
--- a/lib/App/MP4Meta/TV.pm
+++ b/lib/App/MP4Meta/TV.pm
@@ -165,11 +165,6 @@ sub _parse_filename {
         }
     }
 
-    if ( $directories  )
-    {
-        say $directories;
-    }
-
     if ( $directories )
     {
         #-- remove Season N

--- a/lib/App/MP4Meta/TV.pm
+++ b/lib/App/MP4Meta/TV.pm
@@ -17,12 +17,19 @@ use App::MP4Meta::Source::Data::TVEpisode;
 # a list of regexes to try to parse the file
 my @file_regexes = (
     qr/^S(?<season>\d)-E(?<episode>\d)\s+-\s+(?<show>.*)$/,
+    qr/^S(?<season>\d)-E(?<episode>\d)\s*-\s*E(?<end_episode\d)\s+-\s+(?<show>.*)$/,
     qr/^(?<show>.*)\s+S(?<season>\d\d)(\s|)E(?<episode>\d\d)$/,
+    qr/^(?<show>.*)\s+S(?<season>\d\d)(\s|)E(?<episode>\d\d)\s*-\s*E(?<end_episode>\d\d)$/,
     qr/^(?<show>.*)\.S(?<season>\d\d)E(?<episode>\d\d)/i,
+    qr/^(?<show>.*)\.S(?<season>\d\d)E(?<episode>\d\d)\s*-\s*E(?<end_episode>\d\d)/i,
     qr/^(?<show>.*)\s*-?\s*S(?<season>\d\d?)E(?<episode>\d\d?)/i,
+    qr/^(?<show>.*)\s*-?\s*S(?<season>\d\d?)E(?<episode>\d\d?)\s*-\s*E(?<end_episode>\d\d)/i,
     qr/^(?<show>.*)-S(?<season>\d\d?)E(?<episode>\d\d?)/,
-    qr/^(?<show>.*)_S(?<season>\d\d?)E(?<episode>\d\d?)/,
-    qr/S(?<season>\d\d?)E(?<episode>\d\d?)/,
+    qr/^(?<show>.*)-S(?<season>\d\d?)E(?<episode>\d\d?)\s*-\s*E(?<end_episode>\d\d)/,
+    qr/^(?<show>.*)-S(?<season>\d\d?)E(?<episode>\d\d?)/i,
+    qr/^(?<show>.*)-S(?<season>\d\d?)E(?<episode>\d\d?)\s*-\s*E(?<end_episode>\d\d)/i,
+    qr/S(?<season>\d\d?)E(?<episode>\d\d?)/i,
+    qr/S(?<season>\d\d?)E(?<episode>\d\d?)\s*-\s*E(?<end_episode>\d\d?)/i,
     qr/^(?<show>.*)\s*-?\s*(?<season>\d\d?)x(?<episode>\d\d?)/,
 );
 

--- a/lib/App/MP4Meta/TV.pm
+++ b/lib/App/MP4Meta/TV.pm
@@ -144,19 +144,13 @@ sub _parse_filename {
     my ( $self, $directories, $file ) = @_;
 
     my $show = '';
-	my $season = '';
-	my $episode = '';
-    if ( $directories =~ s{/season\s+(\d+)$/?}{}i)
-	{
-		my @parts = (split /\//, $directories);
-		$show = $parts[$#parts];
-	}
+    my $season = '';
+    my $episode = '';
+
     # strip suffix
     $file = $self->_strip_suffix($file);
 
-
     # see if we have a regex that matches
-	# need to parse directories, ignore "Season N/ type directories"
     for my $r (@file_regexes) {
         if ( $file =~ $r ) {
             $show       = $self->{title}   // $+{show};
@@ -170,17 +164,16 @@ sub _parse_filename {
             }
         }
     }
-	if ( $season && $episode)
-	{
-		my @parts = (split /\//, $directories);
-		$show = $parts[$#parts];
-        if ( $show && $season && $episode ) {
 
-            return ( $self->_clean_title($show), int $season, int $episode );
-        }
-	}
-
-
+    if ( $directories =~ s{/season\s+(\d+)$/?}{}i)
+    {
+        my @parts = (split /\//, $directories);
+        $show = $parts[$#parts];
+    }
+    
+    if ( $show && $season && $episode ) {
+        return ( $self->_clean_title($show), int $season, int $episode );
+    }
     return;
 }
 

--- a/lib/App/MP4Meta/TV.pm
+++ b/lib/App/MP4Meta/TV.pm
@@ -17,7 +17,7 @@ use App::MP4Meta::Source::Data::TVEpisode;
 # a list of regexes to try to parse the file
 my @file_regexes = (
     qr/^S(?<season>\d)-E(?<episode>\d)\s+-\s+(?<show>.*)$/,
-    qr/^S(?<season>\d)-E(?<episode>\d)\s*-\s*E(?<end_episode\d)\s+-\s+(?<show>.*)$/,
+    qr/^S(?<season>\d)-E(?<episode>\d)\s*-\s*E(?<end_episode>\d)\s+-\s+(?<show>.*)$/,
     qr/^(?<show>.*)\s+S(?<season>\d\d)(\s|)E(?<episode>\d\d)$/,
     qr/^(?<show>.*)\s+S(?<season>\d\d)(\s|)E(?<episode>\d\d)\s*-\s*E(?<end_episode>\d\d)$/,
     qr/^(?<show>.*)\.S(?<season>\d\d)E(?<episode>\d\d)/i,
@@ -74,7 +74,7 @@ sub apply_meta {
 
         # parse the filename for the title, season and episode
         ( $tags{show_title}, $tags{season}, $tags{episode} ) =
-          $self->_parse_filename($directories, $file);
+          $self->_parse_filename($file, $directories);
         unless ( $tags{show_title} && $tags{season} && $tags{episode} ) {
             return "Error: could not parse the filename for $path";
         }
@@ -141,7 +141,7 @@ sub apply_meta {
 
 # Parse the filename in order to get the series title the and season and episode number.
 sub _parse_filename {
-    my ( $self, $directories, $file ) = @_;
+    my ( $self, $file, $directories ) = @_;
 
     my $show = '';
     my $season = '';
@@ -165,8 +165,15 @@ sub _parse_filename {
         }
     }
 
-    if ( $directories =~ s{/season\s+(\d+)$/?}{}i)
+    if ( $directories  )
     {
+        say $directories;
+    }
+
+    if ( $directories )
+    {
+        #-- remove Season N
+        $directories =~ s{/season\s+(\d+)$/?}{}i;
         my @parts = (split /\//, $directories);
         $show = $parts[$#parts];
     }

--- a/lib/test.pl
+++ b/lib/test.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin;                 # locate this script
+use lib "$FindBin::Bin";
+use App::MP4Meta;
+use App::MP4Meta::TV;
+
+my $tv = App::MP4Meta::TV->new({ sources => [qw{TVDB}] });
+$tv->apply_meta( '/Volumes/Media3/TV Shows/House of Cards (US)/S01E01.mp4');

--- a/t/lib/Test/App/MP4Meta/TV.pm
+++ b/t/lib/Test/App/MP4Meta/TV.pm
@@ -84,7 +84,7 @@ sub apply_meta_set_title : Test(9) {
 }
 
 # test $tv->_parse_filename($filename)
-sub parse_filename : Test(39) {
+sub parse_filename : Test(45) {
     my $self = shift;
     my $t    = $self->{tv};
 
@@ -150,6 +150,18 @@ sub parse_filename : Test(39) {
     is( $title,   'Extras' );
     is( $season,  1 );
     is( $episode, 1 );
+    
+    #-- Plex style rules
+    $t->{title} = '';
+    ( $title, $season, $episode ) = $t->_parse_filename('S06E01-E02 - Bargaining.mkv', '/Volumes/Media3/TV Shows/Buffy the Vampire Slayer/Season 6/');
+    is ( $title, 'Buffy The Vampire Slayer');
+    is ( $season, 6);
+    is ( $episode, 1);
+
+    ( $title, $season, $episode ) = $t->_parse_filename('S06E01-E02 - Bargaining.mkv', '/Volumes/Media3/TV Shows/Buffy the Vampire Slayer/');
+    is ( $title, 'Buffy The Vampire Slayer');
+    is ( $season, 6);
+    is ( $episode, 1);
 }
 
 sub episode_is_complete : Test(2) {


### PR DESCRIPTION
Allow for reading the TV show title from the directory name. The idea here is to match Plex naming rules ( see https://plexapp.zendesk.com/hc/en-us/articles/200220687-Naming-Series-Based-TV-Shows) so that the user can have `/path to/TV Shows/Show Name/Season N/S03E01-E03.mp4` and have the parser determine `Show Name` and episode 1.
- Fix the regexes that match to Plex rules
- invert the order of `$file, $directory` to match previous usage
- unit test.
